### PR TITLE
Trivial Linux documentation changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Stock tf/cfg files not worth tracking in git
+config_arena.cfg
+motd_entries.txt
+replay*.cfg
+server_blacklist.txt
+sixense_bindings.cfg
+user.scr
+config.cfg

--- a/dx9frames
+++ b/dx9frames
@@ -10,6 +10,9 @@
 //
 // Fullscreen: -dxlevel 95 -full -w WIDTH -h HEIGHT -console -novid -useforcedmparms -noforcemaccel -noforcemspd
 // Windowed:   -dxlevel 95 -sw -w WIDTH -h HEIGHT -console -noborder -novid -useforcedmparms -noforcemaccel -noforcemspd
+//
+// FYI: dxlevel launch options have no effect on native OpenGL rendering,
+// for example on platforms such as Linux or Mac OS X.
 // ----------------------------------------------------------------------------
 
 // ----------------------------------------------------------------------------
@@ -201,7 +204,8 @@ mat_disable_lightwarp 1
 mat_envmapsize 8
 mat_envmaptgasize 8
 mat_filterlightmaps 1
-mat_filtertextures 1
+mat_filtertextures 1 // Setting 0 breaks the game on Linux,
+                     // use 1 to avoid graphical glitches.
 mat_forceaniso 1
 mat_hdr_level 0
 mat_max_worldmesh_vertices 512

--- a/highframes
+++ b/highframes
@@ -10,6 +10,9 @@
 //
 // Fullscreen: -dxlevel 81 -full -w WIDTH -h HEIGHT -console -novid -useforcedmparms -noforcemaccel -noforcemspd
 // Windowed:   -dxlevel 81 -sw -w WIDTH -h HEIGHT -console -noborder -novid -useforcedmparms -noforcemaccel -noforcemspd
+//
+// FYI: dxlevel launch options have no effect on native OpenGL rendering,
+// for example on platforms such as Linux or Mac OS X.
 // ----------------------------------------------------------------------------
 
 // ----------------------------------------------------------------------------
@@ -201,7 +204,8 @@ mat_disable_lightwarp 1
 mat_envmapsize 8
 mat_envmaptgasize 8
 mat_filterlightmaps 1
-mat_filtertextures 1
+mat_filtertextures 1 // Setting 0 breaks the game on Linux,
+                     // use 1 to avoid graphical glitches.
 mat_forceaniso 1
 mat_hdr_level 0
 mat_max_worldmesh_vertices 512

--- a/highquality
+++ b/highquality
@@ -10,6 +10,9 @@
 //
 // Fullscreen: -dxlevel 98 -full -w WIDTH -h HEIGHT -console -novid -useforcedmparms -noforcemaccel -noforcemspd
 // Windowed:   -dxlevel 98 -sw -w WIDTH -h HEIGHT -console -noborder -novid -useforcedmparms -noforcemaccel -noforcemspd
+//
+// FYI: dxlevel launch options have no effect on native OpenGL rendering,
+// for example on platforms such as Linux or Mac OS X.
 // ----------------------------------------------------------------------------
 
 // ----------------------------------------------------------------------------

--- a/maxframes
+++ b/maxframes
@@ -10,6 +10,9 @@
 //
 // Fullscreen: -dxlevel 81 -full -w WIDTH -h HEIGHT -console -novid -useforcedmparms -noforcemaccel -noforcemspd
 // Windowed:   -dxlevel 81 -sw -w WIDTH -h HEIGHT -console -noborder -novid -useforcedmparms -noforcemaccel -noforcemspd
+//
+// FYI: dxlevel launch options have no effect on native OpenGL rendering,
+// for example on platforms such as Linux or Mac OS X.
 // ----------------------------------------------------------------------------
 
 // ----------------------------------------------------------------------------
@@ -201,7 +204,8 @@ mat_disable_lightwarp 1
 mat_envmapsize 8
 mat_envmaptgasize 8
 mat_filterlightmaps 0
-mat_filtertextures 0
+mat_filtertextures 0 // Setting 0 breaks the game on Linux,
+                     // use 1 to avoid graphical glitches.
 mat_forceaniso 1
 mat_hdr_level 0
 mat_max_worldmesh_vertices 512

--- a/maxquality
+++ b/maxquality
@@ -10,6 +10,9 @@
 //
 // Fullscreen: -dxlevel 98 -full -w WIDTH -h HEIGHT -console -novid -useforcedmparms -noforcemaccel -noforcemspd
 // Windowed:   -dxlevel 98 -sw -w WIDTH -h HEIGHT -console -noborder -novid -useforcedmparms -noforcemaccel -noforcemspd
+//
+// FYI: dxlevel launch options have no effect on native OpenGL rendering,
+// for example on platforms such as Linux or Mac OS X.
 // ----------------------------------------------------------------------------
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Frequently asked Linux issues via /r/linux_gaming

```
* Update header documentation to reflect `-dxlevel` has no
  effect on native OpenGL rendering for either Mac OS
  or Linux.
* Add note about mat_filtertextures 0 causing graphical
  glitches on Linux.  Use a setting of 1 on Linux to avoid
  graphical glitches.  This is only really a problem on maxframes,
  where it is currently set to 0 by default.
* Added a .gitignore for stock `tf/cfg` files, feel free to take or leave it.

A bit contrived perhaps.  Seems like this keeps coming
up over and over again.  There also seems to be confusion,
regarding the naming convention, i.e. dx9frames, when nothing
DX specific is in the configs themselves.  Rather the naming
convention most likely refers to the recommended DX level on
Windows platforms.
```
