### PR TITLE
Heal Target Markers removed

### DIFF
--- a/highframes
+++ b/highframes
@@ -281,6 +281,8 @@ r_fastzreject -1 // Values >1 enable a fast Z rejection algorithm, to be
                  // performed on the GPU (as opposed to on the CPU). The
                  // value `-1' autodetects hardware support for this
                  // feature, which is safer than forcing it.
+hud_medichealtargetmarker 0 // Removes Heal target markers, this causes the
+                            // medigun beam to disappear in dx8.
 
 // ----------------------------------------------------------------------------
 // Sound

--- a/maxframes
+++ b/maxframes
@@ -281,6 +281,8 @@ r_fastzreject -1 // Values >1 enable a fast Z rejection algorithm, to be
                  // performed on the GPU (as opposed to on the CPU). The
                  // value `-1' autodetects hardware support for this
                  // feature, which is safer than forcing it.
+hud_medichealtargetmarker 0 // Removes Heal target markers, this causes
+                            // the medigun beam to disappear in dx8.
 
 // ----------------------------------------------------------------------------
 // Sound


### PR DESCRIPTION
hud_medichealtargetmarker is set to 0 as to prevent markers being shown
as it causes the median beam to disappear whilst in directx 8. The changes are made to both highframes and maxframes which both use dx8.
